### PR TITLE
Delete @link in inline comment

### DIFF
--- a/app/src/main/java/com/example/android/flavor/AndroidFlavorAdapter.java
+++ b/app/src/main/java/com/example/android/flavor/AndroidFlavorAdapter.java
@@ -67,7 +67,7 @@ public class AndroidFlavorAdapter extends ArrayAdapter<AndroidFlavor> {
                     R.layout.list_item, parent, false);
         }
 
-        // Get the {@link AndroidFlavor} object located at this position in the list
+        // Get the AndroidFlavor object located at this position in the list
         AndroidFlavor currentAndroidFlavor = getItem(position);
 
         // Find the TextView in the list_item.xml layout with the ID version_name


### PR DESCRIPTION
`@link` is used in the inline comment inside the getView function. Clearly, this is not a Javadoc comment hence `@link` won't work.
